### PR TITLE
Extend the maximum lanes per port from 4 to 8

### DIFF
--- a/test/saithrift/src/switch_sai_rpc_server.cpp
+++ b/test/saithrift/src/switch_sai_rpc_server.cpp
@@ -3200,7 +3200,6 @@ public:
       queue_list_object_attribute.value.objlist.count = max_queues;
       port_api->get_port_attribute(port_id, 1, &queue_list_object_attribute);
 
-      thrift_attr_list.attr_count = 2;
       std::vector<sai_thrift_attribute_t>& attr_list = thrift_attr_list.attr_list;
       thrift_queue_list_attribute.id = SAI_PORT_ATTR_QOS_QUEUE_LIST;
       thrift_queue_list_attribute.value.objlist.count = max_queues;
@@ -3226,7 +3225,6 @@ public:
       pg_list_object_attribute.value.objlist.count = max_pg;
       port_api->get_port_attribute(port_id, 1, &pg_list_object_attribute);
 
-      thrift_attr_list.attr_count = 3;
       thrift_pg_list_attribute.id = SAI_PORT_ATTR_INGRESS_PRIORITY_GROUP_LIST;
       thrift_pg_list_attribute.value.objlist.count = max_pg;
       std::vector<sai_thrift_object_id_t>& pg_list = thrift_pg_list_attribute.value.objlist.object_id_list;
@@ -3246,7 +3244,6 @@ public:
       port_hw_lane.value.u32list.count = 8;
       port_api->get_port_attribute(port_id, 1, &port_hw_lane);
 
-      thrift_attr_list.attr_count = 8;
       thrift_port_hw_lane.id = SAI_PORT_ATTR_HW_LANE_LIST;
       thrift_port_hw_lane.value.u32list.count = port_hw_lane.value.u32list.count;
       std::vector<int32_t>& lane_list = thrift_port_hw_lane.value.u32list.u32list;
@@ -3262,7 +3259,6 @@ public:
       port_oper_status_attribute.id = SAI_PORT_ATTR_OPER_STATUS;
       port_api->get_port_attribute(port_id, 1, &port_oper_status_attribute);
 
-      thrift_attr_list.attr_count = 5;
       thrift_port_status.id = SAI_PORT_ATTR_OPER_STATUS;
       thrift_port_status.value.s32 =  port_oper_status_attribute.value.s32;
       attr_list.push_back(thrift_port_status);
@@ -3272,7 +3268,6 @@ public:
       port_mtu_status_attribute.id = SAI_PORT_ATTR_MTU;
       port_api->get_port_attribute(port_id, 1, &port_mtu_status_attribute);
 
-      thrift_attr_list.attr_count = 6;
       thrift_port_mtu.id = SAI_PORT_ATTR_MTU;
       thrift_port_mtu.value.u32 =  port_mtu_status_attribute.value.u32;
       attr_list.push_back(thrift_port_mtu);

--- a/test/saithrift/src/switch_sai_rpc_server.cpp
+++ b/test/saithrift/src/switch_sai_rpc_server.cpp
@@ -1677,8 +1677,8 @@ public:
 
       for (int i=0 ; i<max_ports ; i++){
           port_lane_list_attribute.id = SAI_PORT_ATTR_HW_LANE_LIST;
-          port_lane_list_attribute.value.u32list.list = (uint32_t *) malloc(sizeof(uint32_t) * 4);
-          port_lane_list_attribute.value.u32list.count = 4;
+          port_lane_list_attribute.value.u32list.list = (uint32_t *) malloc(sizeof(uint32_t) * 8);
+          port_lane_list_attribute.value.u32list.count = 8;
           port_api->get_port_attribute(port_list_object_attribute.value.objlist.list[i], 1, &port_lane_list_attribute);
 
           std::set<int> port_lanes;
@@ -1766,8 +1766,8 @@ public:
 
       for (int i=0 ; i<max_ports ; i++){
           port_lane_list_attribute.id = SAI_PORT_ATTR_HW_LANE_LIST;
-          port_lane_list_attribute.value.u32list.list = (uint32_t *) malloc(sizeof(uint32_t) * 4);
-          port_lane_list_attribute.value.u32list.count = 4;
+          port_lane_list_attribute.value.u32list.list = (uint32_t *) malloc(sizeof(uint32_t) * 8);
+          port_lane_list_attribute.value.u32list.count = 8;
           port_api->get_port_attribute(port_list_object_attribute.value.objlist.list[i], 1, &port_lane_list_attribute);
 
           std::set<int> port_lanes;
@@ -3242,11 +3242,11 @@ public:
       sai_u32_list_t *lane_list_num;
 
       port_hw_lane.id = SAI_PORT_ATTR_HW_LANE_LIST;
-      port_hw_lane.value.u32list.list = (uint32_t *) malloc(sizeof(uint32_t) * 4);
-      port_hw_lane.value.u32list.count = 4;
+      port_hw_lane.value.u32list.list = (uint32_t *) malloc(sizeof(uint32_t) * 8);
+      port_hw_lane.value.u32list.count = 8;
       port_api->get_port_attribute(port_id, 1, &port_hw_lane);
 
-      thrift_attr_list.attr_count = 4;
+      thrift_attr_list.attr_count = 8;
       thrift_port_hw_lane.id = SAI_PORT_ATTR_HW_LANE_LIST;
       thrift_port_hw_lane.value.u32list.count = port_hw_lane.value.u32list.count;
       std::vector<int32_t>& lane_list = thrift_port_hw_lane.value.u32list.u32list;


### PR DESCRIPTION
It assumes there are only 4 lanes per port which is not correct because
there are 8 lanes per port on MSN4700 for 400G ports

Signed-off-by: Stephen Sun <stephens@mellanox.com>